### PR TITLE
Make Actions set -eo pipefail

### DIFF
--- a/.github/workflows/provision.yaml
+++ b/.github/workflows/provision.yaml
@@ -26,14 +26,14 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Download the toolkit-cli
-      run: bin/install-toolkit-cli
       shell: bash
+      run: bin/install-toolkit-cli
 
     - name: Write Snowflake private key
+      shell: bash
       run: |
        (umask  077 ; echo $SNOWFLAKE_PRIVATE_KEY_PEM | base64 --decode > /tmp/snowboarder_it.p8)
        echo "SNOWFLAKE_PRIVATE_KEY_FILE=/tmp/snowboarder_it.p8" >> $GITHUB_ENV
-      shell: bash
   
     - name: Set up Java 
       uses: actions/setup-java@v3
@@ -43,9 +43,11 @@ jobs:
       
     - name: Plan on pull request
       if: github.event_name == 'pull_request'
+      shell: bash
       run: install/toolkit provision apply --plan | tee plan.log
     
     - name: Apply changes on merge to master
+      shell: bash
       run: install/toolkit provision apply --approve | tee plan.log
       if: github.event_name == 'push'
 


### PR DESCRIPTION
Without setting the shell explicitly operations failing before a pipe will cause the step to succeed.